### PR TITLE
Rebase macos iceprog

### DIFF
--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -1,18 +1,40 @@
 include ../config.mk
 
+ifeq ($(OS),macos)
+$(info Compiling for macOS)
+
 ifeq ($(STATIC),1)
 LDFLAGS += -static
-else
+else #ifeq ($(STATIC),1)
 
-# CFLAGS += -llibusb-1.0
 LDLIBS += -lusb-1.0
-endif
-#LDLIBS += -framework IOKit -framework CoreFoundation -framework AppKit
+endif #ifeq ($(STATIC),1)
+
+else #ifeq ($(OS),macos)
+
+ifeq ($(STATIC),1)
+LDFLAGS += -static
+LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --static --libs $$pkg && exit; done; echo -lftdi; )
+CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --static --cflags $$pkg && exit; done; )
+else
+LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --libs $$pkg && exit; done; echo -lftdi; )
+CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --cflags $$pkg && exit; done; )
+
+CFLAGS += -llibusb-1.0
+LDLIBS += -lusb-1.0
+endif #ifeq ($(STATIC),1)
+
+endif #ifeq ($(OS),macos)
 
 all: $(PROGRAM_PREFIX)iceprog$(EXE)
 
+ifeq ($(OS),macos)
 $(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o rpi_pico_interface.o
 	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)
+else
+$(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o mpsse.o ftdi_interface.o rpi_pico_interface.o
+	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)
+endif
 
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -2,19 +2,16 @@ include ../config.mk
 
 ifeq ($(STATIC),1)
 LDFLAGS += -static
-LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --static --libs $$pkg && exit; done; echo -lftdi; )
-CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --static --cflags $$pkg && exit; done; )
 else
-LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --libs $$pkg && exit; done; echo -lftdi; )
-CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --cflags $$pkg && exit; done; )
 
-CFLAGS += -llibusb-1.0
+# CFLAGS += -llibusb-1.0
 LDLIBS += -lusb-1.0
 endif
+#LDLIBS += -framework IOKit -framework CoreFoundation -framework AppKit
 
 all: $(PROGRAM_PREFIX)iceprog$(EXE)
 
-$(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o mpsse.o ftdi_interface.o rpi_pico_interface.o
+$(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o rpi_pico_interface.o
 	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)
 
 install: all
@@ -32,4 +29,3 @@ clean:
 -include *.d
 
 .PHONY: all install uninstall clean
-

--- a/iceprog/Makefile
+++ b/iceprog/Makefile
@@ -1,14 +1,10 @@
 include ../config.mk
 
 ifeq ($(OS),macos)
-$(info Compiling for macOS)
+$(info Compiling for macOS, expects libsub installed via Homebrew.)
 
-ifeq ($(STATIC),1)
-LDFLAGS += -static
-else #ifeq ($(STATIC),1)
-
-LDLIBS += -lusb-1.0
-endif #ifeq ($(STATIC),1)
+CFLAGS += -I /opt/homebrew/include
+LDFLAGS += -L /opt/homebrew/lib -lusb-1.0
 
 else #ifeq ($(OS),macos)
 
@@ -20,7 +16,6 @@ else
 LDLIBS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --libs $$pkg && exit; done; echo -lftdi; )
 CFLAGS += $(shell for pkg in libftdi1 libftdi; do $(PKG_CONFIG) --silence-errors --cflags $$pkg && exit; done; )
 
-CFLAGS += -llibusb-1.0
 LDLIBS += -lusb-1.0
 endif #ifeq ($(STATIC),1)
 
@@ -30,7 +25,7 @@ all: $(PROGRAM_PREFIX)iceprog$(EXE)
 
 ifeq ($(OS),macos)
 $(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o rpi_pico_interface.o
-	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)
+	$(CC) $(CFLAGS) -o $@ $(LDFLAGS) $^ $(LDLIBS)
 else
 $(PROGRAM_PREFIX)iceprog$(EXE): iceprog.o mpsse.o ftdi_interface.o rpi_pico_interface.o
 	$(CC) -o $@ $(LDFLAGS) $^ $(LDLIBS)

--- a/iceprog/README.md
+++ b/iceprog/README.md
@@ -1,0 +1,42 @@
+## Build
+
+To build Iceprog simply run
+
+```
+$ make
+```
+
+If a prefix for the compiled firmware is wanted use for example
+
+```
+$ make PROGRAM_PREFIX=tillitis-
+```
+to produce a program named `tillitis-iceprog`
+
+Use
+
+```
+sudo make PROGRAM_PREFIX=tillitis- install
+```
+to install the program in `/usr/local/bin`
+
+
+### macOS
+
+To build on macOS use
+
+```
+$ make OS=macos
+```
+
+Pre-requisites for building on macOS is the library [`libusb`](https://github.com/libusb/libusb).
+
+Build and install it by downlaoding the source and read the instructions in `INSTALL` in `libusb`.
+
+The short version is: download and unpack, enter the folder and run
+
+```
+$ ./configure
+$ make
+$ make install
+```

--- a/iceprog/README.md
+++ b/iceprog/README.md
@@ -1,5 +1,4 @@
 ## Build
-
 To build Iceprog simply run
 
 ```
@@ -7,36 +6,28 @@ $ make
 ```
 
 If a prefix for the compiled firmware is wanted use for example
-
 ```
 $ make PROGRAM_PREFIX=tillitis-
 ```
 to produce a program named `tillitis-iceprog`
 
-Use
-
+To install the program in `/usr/local/bin` use
 ```
 sudo make PROGRAM_PREFIX=tillitis- install
 ```
-to install the program in `/usr/local/bin`
-
 
 ### macOS
-
 To build on macOS use
 
 ```
 $ make OS=macos
 ```
 
-Pre-requisites for building on macOS is the library [`libusb`](https://github.com/libusb/libusb).
-
-Build and install it by downlaoding the source and read the instructions in `INSTALL` in `libusb`.
-
-The short version is: download and unpack, enter the folder and run
+Pre-requisites for building iceprog is the library
+[`libusb`](https://github.com/libusb/libusb). For most Linux distros
+this comes pre-installed, but for macOS it needs to be installed
+manually. Simplest is through Homebrew using
 
 ```
-$ ./configure
-$ make
-$ make install
+$ brew install libusb
 ```


### PR DESCRIPTION
Rebased `iceprog_tillitis_macos` onto `interfaces` to support the newer raw USB protocol.
Removed unused HID files for macos. 

Added so both macos and linux can be build using the same makefile. 
Added readme for clarity.