### PR TITLE
Fix bit-shift of pin CRESET

### DIFF
--- a/iceprog/rpi_pico_interface.c
+++ b/iceprog/rpi_pico_interface.c
@@ -232,7 +232,7 @@ static void error(int status) {
 
 static void set_cs_creset(int cs_b, int creset_b) {
     pinmask_write(
-        (1<<PIN_SS) | (1<PIN_CRESET),
+        (1<<PIN_SS) | (1<<PIN_CRESET),
         ((cs_b>0?1:0)<<PIN_SS) | ((creset_b>0?1:0)<<PIN_CRESET)
     );
 }


### PR DESCRIPTION
## Description
CRESET of the FPGA was not properly controlled

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)


## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
